### PR TITLE
Fix typos in permission statement and follow header conventions

### DIFF
--- a/manued.el
+++ b/manued.el
@@ -13,13 +13,15 @@
 
 ;; This program is free software; you can redistribute it and/or modify
 ;; it under the terms of the GNU General Public License as published by
-;; the Free Software Foundation; either versions 2, or (at your option)
+;; the Free Software Foundation; either version 2, or (at your option)
 ;; any later version.
 
-;; This program is distributed in the hope that it will be useful
+;; This program is distributed in the hope that it will be useful,
 ;; but WITHOUT ANY WARRANTY; without even the implied warranty of
 ;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 ;; GNU General Public License for more details.
+
+;; For a full copy of the GNU General Public License
 ;; see <http://www.gnu.org/licenses/>.
 
 ;;; Commentary:

--- a/manued.el
+++ b/manued.el
@@ -1,53 +1,56 @@
-;;;
 ;;; manued.el --- a minor mode of manued proofreading method.
-;;;
-;;; Author: Hitoshi Yamauchi
-;;; Maintainer: Hitoshi Yamauchi
-;;; Created: 16 Jan 1998
-;;; Keywords: proofreading, docs
-;;;
-;;; Contributors: Atusi Maeda
-;;;	          Stefan Monnier (0.9.1)
-;;;	          Mikio Nakajima (0.9.3)
-;;;	          Takao Kawamura (0.9.3)
-;;;
-;;; This file is not part of GNU Emacs.
-;;;
-;;; This program is free software; you can redistribute it and/or modify
-;;; it under the terms of the GNU General Public License as published by
-;;; the Free Software Foundation; either versions 2, or (at your option)
-;;; any later version.
-;;;
-;;; This program is distributed in the hope that it will be useful
-;;; but WITHOUT ANY WARRANTY; without even the implied warranty of
-;;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-;;; GNU General Public License for more details.
-;;; see <http://www.gnu.org/licenses/>.
-;;;
 
-;;;
-;;; Manued stands for MANUscripting EDitor.
-;;;
-;;; Original idea of manued:
-;;;	Ikuo Takeuchi, ``Manuscripting Editing on E-mail,'' 39th
-;;;	Programming Symposium, 1998, January, pp.61--68
-;;;
-;;;	The original paper is written in Japanese,
-;;;	竹内郁雄, ``電子メールで原稿を修正する方法 --- Manuscript
-;;;     Editing (Manued, 真鵺道)を目指して ---'', 第 39 回プログラミン
-;;;	グシンポジウム, 1998, 1月, pp.61--68
-;;;
-;;;
+;; Author: Hitoshi Yamauchi
+;; Maintainer: Hitoshi Yamauchi
+;; Created: 16 Jan 1998
+;; Keywords: proofreading, docs
+;; Contributors: Atusi Maeda
+;;	         Stefan Monnier (0.9.1)
+;;	         Mikio Nakajima (0.9.3)
+;;	         Takao Kawamura (0.9.3)
+
+;; This file is not part of GNU Emacs.
+
+;; This program is free software; you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either versions 2, or (at your option)
+;; any later version.
+
+;; This program is distributed in the hope that it will be useful
+;; but WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+;; GNU General Public License for more details.
+;; see <http://www.gnu.org/licenses/>.
+
+;;; Commentary:
+
+;; A minor mode implementing manued proofreading method.
+;;
+;; Manued stands for MANUscripting EDitor.
+;;
+;; Original idea of manued:
+;;	Ikuo Takeuchi, ``Manuscripting Editing on E-mail,'' 39th
+;;	Programming Symposium, 1998, January, pp.61--68
+;;
+;;	The original paper is written in Japanese,
+;;	竹内郁雄, ``電子メールで原稿を修正する方法 --- Manuscript
+;;     Editing (Manued, 真鵺道)を目指して ---'', 第 39 回プログラミン
+;;	グシンポジウム, 1998, 1月, pp.61--68
+;;
+;;
 ;;------------------------------------------------------------
 ;; debug 用の message 出力
 ;;------------------------------------------------------------
 ;; delete at release
 ;;(setq debug-on-error t)
 ;;(defun dbg (mes) (print mes (get-buffer "manued-debug")))
-
+;;
 ;;------------------------------------------------------------
 ;; constant values
 ;;------------------------------------------------------------
+
+;;; Code:
+
 (defconst manued-version-num   "0.9.5-current"
   "The version of manued.el.
 真鵺道のバージョン")


### PR DESCRIPTION
I am opening this pull-request because of this:

----

Improve how the license is specified

I am the maintainer of the [Emacsmirror](https://emacsmirror.org), which mirrors more than seven thousand Emacs packages.  Each package [is distributed](https://github.com/emacsmirror) as a Git repository.

Because I distribute these packages, I have to worry about how they are licensed.  Packages should be compatible with the license used by Emacs, i.e. version 3 of the GPL.  To ensure that this is the case I obviously have to detect the license.

I have written a library to do so called [`elx`](https://github.com/emacscollective/elx).  It can extract the license from the permission statement at the beginning of a "main" library, the `License` header at the beginning of the library, or the `LICENSE` file in the same repository.

In theory that should get the job done, but with more than 7000 packages we have to expect some issues.  Over the years `elx` therefore has been taught about variations of the default permission statements that are used in the wild and even many non-standard permission statements that, while possibly weird, still unambiguously identify the license.

Finally a handful of packages (15 out of 7328) specify the license in a way where even that is not enough. For these packages it was necessary to hardcode the license inside of `elx`.  

Unfortunately this package is one of them.

This pull-request changes how the license is specified, it does *not* change the license.